### PR TITLE
chore: use HTTPS repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Prettier config for our projects",
   "type": "module",
   "main": "prettierrc.json",
-  "repository": "git@github.com:bifravst/prettier-config.git",
+  "repository": "git+https://github.com/bifravst/prettier-config.git",
   "homepage": "https://github.com/bifravst/prettier-config",
   "author": "Nordic Semiconductor ASA | nordicsemi.no",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
## Summary
- update the package repository metadata from an SSH URL to the public `git+https` Git URL
- leave runtime code, dependencies, version, and package contents unchanged

## Validation
- node metadata assertion for `package.json`
- `npm ci --ignore-scripts` (completed; existing audit reports 3 moderate and 3 high vulnerabilities)
- `npx prettier --check package.json`
- `PATH="$PWD/node_modules/.bin:$PATH" npm pack --dry-run --json .`
- `git diff --check`
